### PR TITLE
Update gitignore to include all logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ config.json
 data/serverdict_backup
 data/serverdict
 
-logs/meowth.log
+logs/
 __pychache__/
 *.py[cod]


### PR DESCRIPTION
On my server, `ls logs/` returns `meowth_backup.log  meowth.log  meowth.log.1  meowth.log.2`. None of these need to be in the repository so they probably should be ignored.